### PR TITLE
Duck Duck Go as DuckDuckGo

### DIFF
--- a/data/filters/search-results.yaml
+++ b/data/filters/search-results.yaml
@@ -5,7 +5,7 @@ params:
     type: checkbox
     default: true
   - name: duckduckgo
-    description: Generate rules for Duck Duck Go
+    description: Generate rules for DuckDuckGo
     type: checkbox
     default: true
   - name: startpage


### PR DESCRIPTION
Basically the search engine's name is DuckDuckGo, not Duck Duck Go