### PR TITLE
Block end-of-video suggestions overlay

### DIFF
--- a/data/filters/youtube-recommendations.yaml
+++ b/data/filters/youtube-recommendations.yaml
@@ -34,11 +34,25 @@ tests:
     output: |
       www.youtube.com###related
   - params:
+      end-of-video-overlay: true
+    output: |
+      www.youtube.com##.ytp-ce-element
+  - params:
+      homepage-recommendations: true
+    output: |
+      www.youtube.com##ytd-browse[page-subtype="home"]
+  - params:
       related-videos: true
       homepage-recommendations: true
     output: |
       www.youtube.com###related
       www.youtube.com##ytd-browse[page-subtype="home"]
+  - params:
+      related-videos: true
+      end-of-video-overlay: true
+    output: |
+      www.youtube.com###related
+      www.youtube.com##.ytp-ce-element
   - params:
       related-videos: true
       homepage-recommendations: true

--- a/data/filters/youtube-recommendations.yaml
+++ b/data/filters/youtube-recommendations.yaml
@@ -8,6 +8,10 @@ params:
     description: Hide video suggestions on the homepage
     type: checkbox
     default: true
+  - name: end-of-video-overlay
+    description: Hide video suggestions that obscure the end of the video
+    type: checkbox
+    default: true
 tags:
   - youtube
 attribution:
@@ -18,6 +22,9 @@ template: |
   {{/if}}
   {{#if homepage-recommendations}}
   www.youtube.com##ytd-browse[page-subtype="home"]
+  {{/if}}
+  {{#if end-of-video-overlay}}
+  www.youtube.com##.ytp-ce-element
   {{/if}}
 tests:
   - params: {}
@@ -32,6 +39,14 @@ tests:
     output: |
       www.youtube.com###related
       www.youtube.com##ytd-browse[page-subtype="home"]
+  - params:
+      related-videos: true
+      homepage-recommendations: true
+      end-of-video-overlay: true
+    output: |
+      www.youtube.com###related
+      www.youtube.com##ytd-browse[page-subtype="home"]
+      www.youtube.com##.ytp-ce-element
 ---
 The Youtube algorithm is not relevant for you? Just stick to your subscriptions,
 and keep clickbait out of your screen.


### PR DESCRIPTION
YouTube displays an annoying overlay over the last ~5 seconds of the video. This sometimes obscures content. Block it.

Test it, and also add some additional test cases.

Context: `.ytp-ce-element` represents video suggestions, channel suggestions etc.

