### PR TITLE
set lists to refresh faster on latest uBO

### DIFF
--- a/cmd/render/testdata/expected.txt
+++ b/cmd/render/testdata/expected.txt
@@ -1,5 +1,5 @@
 ! Title: letsblock.it - locally rendered list
-! Expires: 1 day
+! Expires: 12 hours
 ! Homepage: https://letsblock.it
 ! License: https://github.com/xvello/letsblockit/blob/main/LICENSE.txt
 

--- a/src/filters/list.go
+++ b/src/filters/list.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	listHeaderTemplate = `! Title: letsblock.it - %s
-! Expires: 1 day
+! Expires: 12 hours
 ! Homepage: https://letsblock.it
 ! License: https://github.com/xvello/letsblockit/blob/main/LICENSE.txt
 `

--- a/src/filters/list_test.go
+++ b/src/filters/list_test.go
@@ -32,7 +32,7 @@ func (s *ListTestSuite) TestRenderEmpty() {
 	list := &List{}
 	s.NoError(list.Render(buf, s.logger, s.repository))
 	s.Equal(`! Title: letsblock.it - 
-! Expires: 1 day
+! Expires: 12 hours
 ! Homepage: https://letsblock.it
 ! License: https://github.com/xvello/letsblockit/blob/main/LICENSE.txt
 `, buf.String())
@@ -58,7 +58,7 @@ func (s *ListTestSuite) TestRenderOK() {
 	s.expectL.Warnf(gomock.Any(), "unknown", gomock.Any())
 	s.NoError(list.Render(buf, s.logger, s.repository))
 	s.Equal(`! Title: letsblock.it - Test list
-! Expires: 1 day
+! Expires: 12 hours
 ! Homepage: https://letsblock.it
 ! License: https://github.com/xvello/letsblockit/blob/main/LICENSE.txt
 

--- a/src/server/list_test.go
+++ b/src/server/list_test.go
@@ -62,7 +62,7 @@ func (s *ServerTestSuite) TestRenderList_OK() {
 	s.server.echo.ServeHTTP(rec, req)
 	s.Equal(200, rec.Code)
 	s.Equal(rec.Body.String(), `! Title: letsblock.it - My filters
-! Expires: 1 day
+! Expires: 12 hours
 ! Homepage: https://letsblock.it
 ! License: https://github.com/xvello/letsblockit/blob/main/LICENSE.txt
 


### PR DESCRIPTION
uBlock Origin v1.42 supports refresh rates as low as 12 hours now, let's make good use of this, for fixes to ship faster to users.
If the traffic to the server becomes too high in the future, we can revert to a longer period.