### PR TITLE
youtube-cleanup: hide comments based on words

### DIFF
--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -16,6 +16,13 @@ params:
     description: Hide the comment section below a video.
     type: checkbox
     default: false
+  - name: remove-specific-comments
+    description: Hide only comments with specific words
+    type: checkbox
+  - name: keywords
+    description: "Keywords to block"
+    type: list
+    default: [ Idiot ]
 tags:
   - youtube
 template: |
@@ -34,6 +41,11 @@ template: |
   {{#if remove-comment-section}}
   www.youtube.com###comments #contents:remove()
   {{/if}}
+  {{#each keywords as |keyword id|}}
+  {{#if ../remove-specific-comments}}
+  www.youtube.com###comment:has-text({{keyword}}):upward(1)
+  {{/if}}
+  {{/each}}
 tests:
   - params: {}
     output: ""
@@ -56,6 +68,11 @@ tests:
       remove-comment-section: true
     output: |
       www.youtube.com###comments #contents:remove()
+  - params:
+      remove-specific-comments: true
+      keywords: [ "Keyword1" ]
+    output: |
+      www.youtube.com###comment:has-text(Keyword1):upward(1)
 ---
 
 Youtube has a lot of text around their videos, which is not really necessary, such as channel clarifications and  

--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -69,7 +69,7 @@ tests:
       remove-comments-with-words: true
       keywords: [ "Keyword1" ]
     output: |
-      www.youtube.com###comment:has-text(Keyword1):upward(1)
+      www.youtube.com###content-text:has-text(/\b(word)\b/i):upward(ytd-comment-thread-renderer)
 ---
 
 Youtube has a lot of text around their videos, which is not really necessary, such as channel clarifications and  

--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -16,13 +16,10 @@ params:
     description: Hide the comment section below a video.
     type: checkbox
     default: false
-  - name: remove-specific-comments
-    description: Hide only comments with specific words
-    type: checkbox
-  - name: keywords
-    description: "Keywords to block"
+  - name: remove-comments-with-words
+    description: Hide comments containing the following words
     type: list
-    default: [ Idiot ]
+    default: [ ]
 tags:
   - youtube
 template: |

--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -65,9 +65,8 @@ tests:
       www.youtube.com###comments #contents:remove()
   - params:
       remove-comments-with-words: true
-      keywords: [ "Keyword1" ]
     output: |
-      www.youtube.com##ytd-comments #content-text:has-text(/\bKeyword1\b/i):upward(ytd-comment-thread-renderer)
+      www.youtube.com##ytd-comments #content-text:has-text(/\b\b/i):upward(ytd-comment-thread-renderer)
 ---
 
 Youtube has a lot of text around their videos, which is not really necessary, such as channel clarifications and  

--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -67,7 +67,7 @@ tests:
       remove-comments-with-words: true
       keywords: [ "Keyword1" ]
     output: |
-      www.youtube.com##ytd-comments #content-text:has-text(/\b{{Keyword1}}\b/i):upward(ytd-comment-thread-renderer)
+      www.youtube.com##ytd-comments #content-text:has-text(/\bKeyword1\b/i):upward(ytd-comment-thread-renderer)
 ---
 
 Youtube has a lot of text around their videos, which is not really necessary, such as channel clarifications and  

--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -37,11 +37,8 @@ template: |
   {{/if}}
   {{#if remove-comment-section}}
   www.youtube.com###comments #contents:remove()
-  {{/if}}
-  {{#each keywords as |keyword id|}}
-  {{#if ../remove-comments-with-words}}
-  www.youtube.com###comment:has-text({{keyword}}):upward(1)
-  {{/if}}
+  {{#each remove-comments-with-words}}
+  www.youtube.com##ytd-comments #content-text:has-text(/\b{{this}}\b/i):upward(ytd-comment-thread-renderer)
   {{/each}}
 tests:
   - params: {}
@@ -69,7 +66,7 @@ tests:
       remove-comments-with-words: true
       keywords: [ "Keyword1" ]
     output: |
-      www.youtube.com###content-text:has-text(/\b(word)\b/i):upward(ytd-comment-thread-renderer)
+      www.youtube.com##ytd-comments #content-text:has-text(/\b{{Keyword1}}\b/i):upward(ytd-comment-thread-renderer)
 ---
 
 Youtube has a lot of text around their videos, which is not really necessary, such as channel clarifications and  

--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -39,7 +39,7 @@ template: |
   www.youtube.com###comments #contents:remove()
   {{/if}}
   {{#each keywords as |keyword id|}}
-  {{#if ../remove-specific-comments}}
+  {{#if ../remove-comments-with-words}}
   www.youtube.com###comment:has-text({{keyword}}):upward(1)
   {{/if}}
   {{/each}}
@@ -66,7 +66,7 @@ tests:
     output: |
       www.youtube.com###comments #contents:remove()
   - params:
-      remove-specific-comments: true
+      remove-comments-with-words: true
       keywords: [ "Keyword1" ]
     output: |
       www.youtube.com###comment:has-text(Keyword1):upward(1)

--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -37,6 +37,7 @@ template: |
   {{/if}}
   {{#if remove-comment-section}}
   www.youtube.com###comments #contents:remove()
+  {{/if}}
   {{#each remove-comments-with-words}}
   www.youtube.com##ytd-comments #content-text:has-text(/\b{{this}}\b/i):upward(ytd-comment-thread-renderer)
   {{/each}}

--- a/data/filters/youtube-cleanup.yaml
+++ b/data/filters/youtube-cleanup.yaml
@@ -64,9 +64,12 @@ tests:
     output: |
       www.youtube.com###comments #contents:remove()
   - params:
-      remove-comments-with-words: true
+      remove-comments-with-words:
+        - word1
+        - word pair2
     output: |
-      www.youtube.com##ytd-comments #content-text:has-text(/\b\b/i):upward(ytd-comment-thread-renderer)
+      www.youtube.com##ytd-comments #content-text:has-text(/\bword1\b/i):upward(ytd-comment-thread-renderer)
+      www.youtube.com##ytd-comments #content-text:has-text(/\bword pair2\b/i):upward(ytd-comment-thread-renderer)
 ---
 
 Youtube has a lot of text around their videos, which is not really necessary, such as channel clarifications and  


### PR DESCRIPTION
I don't know if the default keyword is a good one.
It only show for which purpose you can use this rule